### PR TITLE
Use the same C extension for half filling and low filling by default

### DIFF
--- a/src/fqe/fqe_data.py
+++ b/src/fqe/fqe_data.py
@@ -95,7 +95,12 @@ class FqeData:
         else:
             self._core = fcigraph
         self._dtype = dtype
-        self._low_thresh = 0.3
+
+        if fqe.settings.use_accelerated_code:
+            # Use the same C extension for both cases by default
+            self._low_thresh = 0.0
+        else:
+            self._low_thresh = 0.3
         self._nele = self.nalpha() + self.nbeta()
         self._m_s = self.nalpha() - self.nbeta()
         self.coeff = numpy.zeros((self.lena(), self.lenb()),

--- a/tests/fqe_data_test.py
+++ b/tests/fqe_data_test.py
@@ -1326,6 +1326,7 @@ def test_lowfilling_2_body(c_or_python):
           ]],
         dtype=numpy.complex128)
     work = fqe_data.FqeData(2, 2, norb)
+    work._low_thresh = 0.3 # enable low-filling code for C and python
     work.coeff = numpy.copy(wfn)
     test = work.apply(tuple([h1e_spa, h2e_spa]))
     assert numpy.allclose(numpy.multiply(wfn, scale), test.coeff)


### PR DESCRIPTION
I also checked the threshold for switching between the two python algorithms (`FqeDataSet._low_thresh`) and the crossover in CPU time is remarkably close to to the current 0.3 threshold. Test coverage remains at 100%.